### PR TITLE
Fix keymap path in S01beepykbd

### DIFF
--- a/init/S01beepykbd
+++ b/init/S01beepykbd
@@ -11,7 +11,7 @@
 umask 077
 
 start() {
-	/usr/bin/loadkeys /usr/local/share/kbd/keymapsbeepy-kbd.map
+	/usr/bin/loadkeys /usr/local/share/kbd/keymaps/beepy-kbd.map
 	# System clock has to be set from hwclock after udev is loaded
 	echo "OK"
 }


### PR DESCRIPTION
The keymap file seems to be in /usr/local/share/kbd/keymaps and looks like there was a typo in the init.d script.